### PR TITLE
Export Xor8 struct fields

### DIFF
--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -20,7 +20,7 @@ func TestBasic(t *testing.T) {
 	}
 	falsesize := 1000000
 	matches := 0
-	bpv := float64(len(filter.fingerprints)) * 8.0 / float64(testsize)
+	bpv := float64(len(filter.Fingerprints)) * 8.0 / float64(testsize)
 	fmt.Println("bits per entry ", bpv)
 	assert.Equal(t, true, bpv < 10.)
 	for i := 0; i < falsesize; i++ {


### PR DESCRIPTION
In order to serialize the Xor8 struct for later use (e.g. with `json.Marshal(filter)` or similar), we need to make its fields public by starting them with capital letters.