### PR TITLE
benchmark code for Populate() and Contains().

### DIFF
--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -32,5 +32,31 @@ func TestBasic(t *testing.T) {
 	fpp := float64(matches) * 100.0 / float64(falsesize)
 	fmt.Println("false positive rate ", fpp)
 	assert.Equal(t, true, fpp < 0.40)
+}
 
+func BenchmarkPopulate100000(b *testing.B) {
+	testsize := 10000
+	keys := make([]uint64, testsize, testsize)
+	for i := range keys {
+		keys[i] = rand.Uint64()
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Populate(keys)
+	}
+}
+
+func BenchmarkContains100000(b *testing.B) {
+	testsize := 10000
+	keys := make([]uint64, testsize, testsize)
+	for i := range keys {
+		keys[i] = rand.Uint64()
+	}
+	filter := Populate(keys)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		filter.Contains(keys[n%len(keys)])
+	}
 }


### PR DESCRIPTION
Give below output on my ubuntu machine.

```text
bits per entry  9.864                                                                                                                                                         
false positive rate  0.3874                                                                                                                                                   
goos: linux                                                                                                                                                                   
goarch: amd64                                                                                                                                                                 
pkg: github.com/prataprc/xorfilter                                                                                                                                            
BenchmarkPopulate100000-32          2023            612196 ns/op                                                                                                              
BenchmarkContains100000-32      192364164                6.23 ns/op   
```