### PR TITLE
chore:go fmt && go mod initialize && add allocs to benchmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/FastFilter/xorfilter
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/xorfilter.go
+++ b/xorfilter.go
@@ -51,7 +51,7 @@ func mixsplit(key, seed uint64) uint64 {
 }
 
 func rotl64(n uint64, c int) uint64 {
-	return (n << uint(c & 63)) | (n >> uint((-c) & 63))
+	return (n << uint(c&63)) | (n >> uint((-c)&63))
 }
 
 func reduce(hash, n uint32) uint32 {

--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -41,7 +41,7 @@ func BenchmarkPopulate100000(b *testing.B) {
 		keys[i] = rand.Uint64()
 	}
 
-    b.ReportAllocs()
+	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		Populate(keys)
@@ -56,7 +56,7 @@ func BenchmarkContains100000(b *testing.B) {
 	}
 	filter := Populate(keys)
 
-    b.ReportAllocs()
+	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		filter.Contains(keys[n%len(keys)])

--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -41,6 +41,7 @@ func BenchmarkPopulate100000(b *testing.B) {
 		keys[i] = rand.Uint64()
 	}
 
+    b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		Populate(keys)
@@ -55,6 +56,7 @@ func BenchmarkContains100000(b *testing.B) {
 	}
 	filter := Populate(keys)
 
+    b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		filter.Contains(keys[n%len(keys)])


### PR DESCRIPTION
    The benchmark is as the following:

    > go test -bench .
    goos: darwin
    goarch: amd64
    pkg: github.com/FastFilter/xorfilter
    BenchmarkPopulate100000-8           2101            489025 ns/op          619828 B/op          9 allocs/op
    BenchmarkContains100000-8       121529901                9.49 ns/op            0 B/op          0 allocs/op
    PASS
    ok      github.com/FastFilter/xorfilter 3.303s