### PR TITLE
Removed Iterations For Duplicates

### DIFF
--- a/fusefilter.go
+++ b/fusefilter.go
@@ -1,8 +1,6 @@
 package xorfilter
 
-import (
-	"errors"
-)
+import "errors"
 
 // The Fuse8 xor filter uses 8-bit fingerprints. It offers the same <0.4% false-positive probability
 // as the xor filter, but uses less space (~9.1 bits/entry vs ~9.9 bits/entry).
@@ -94,103 +92,106 @@ func PopulateFuse8(keys []uint64) (*Fuse8, error) {
 	H := make([]xorset, capacity, capacity)
 	Q := make([]keyindex, capacity, capacity)
 	stack := make([]keyindex, size, size)
-	iterations := 0
-	for true {
-		iterations += 1
-		if iterations > MaxIterations {
-			return nil, errors.New("too many iterations, you probably have duplicate keys")
-		}
+	// iterations := 0
+	// for true {
+	// 	iterations += 1
+	// 	if iterations > MaxIterations {
+	// 		return nil, errors.New("too many iterations, you probably have duplicate keys")
+	// 	}
 
-		// Add all keys to the construction array.
-		for _, key := range keys {
-			hs := filter.makeKeyHashes(key)
+	// Add all keys to the construction array.
+	for _, key := range keys {
+		hs := filter.makeKeyHashes(key)
 
-			H[hs.h0].xormask ^= hs.h
-			H[hs.h0].count++
-			H[hs.h1].xormask ^= hs.h
-			H[hs.h1].count++
-			H[hs.h2].xormask ^= hs.h
-			H[hs.h2].count++
-		}
-
-		Qsize := 0
-		// Add sets with one key to the queue.
-		for i := uint32(0); i < capacity; i++ {
-			if H[i].count == 1 {
-				Q[Qsize].index = i
-				Q[Qsize].hash = H[i].xormask
-				Qsize++
-			}
-		}
-
-		stacksize := 0
-		for Qsize > 0 {
-			Qsize--
-			ki := Q[Qsize]
-			index := ki.index
-			if H[index].count == 0 {
-				continue // not actually possible after the initial scan
-			}
-
-			hash := ki.hash
-			hs := filter.geth012(hash)
-
-			stack[stacksize] = ki
-			stacksize++
-
-			// Remove key added to stack from all sets in the construction array and
-			// enqueue sets that now have one key.
-			H[hs.h0].xormask ^= hash
-			H[hs.h0].count--
-			if H[hs.h0].count == 1 {
-				Q[Qsize].index = hs.h0
-				Q[Qsize].hash = H[hs.h0].xormask
-				Qsize++
-			}
-			H[hs.h1].xormask ^= hash
-			H[hs.h1].count--
-			if H[hs.h1].count == 1 {
-				Q[Qsize].index = hs.h1
-				Q[Qsize].hash = H[hs.h1].xormask
-				Qsize++
-			}
-			H[hs.h2].xormask ^= hash
-			H[hs.h2].count--
-			if H[hs.h2].count == 1 {
-				Q[Qsize].index = hs.h2
-				Q[Qsize].hash = H[hs.h2].xormask
-				Qsize++
-			}
-		}
-
-		if stacksize == size {
-			// Success
-			break
-		}
-
-		for i := range H {
-			H[i] = xorset{0, 0}
-		}
-		filter.Seed = splitmix64(&rngcounter)
+		H[hs.h0].xormask ^= hs.h
+		H[hs.h0].count++
+		H[hs.h1].xormask ^= hs.h
+		H[hs.h1].count++
+		H[hs.h2].xormask ^= hs.h
+		H[hs.h2].count++
 	}
+
+	Qsize := 0
+	// Add sets with one key to the queue.
+	for i := uint32(0); i < capacity; i++ {
+		if H[i].count == 1 {
+			Q[Qsize].index = i
+			Q[Qsize].hash = H[i].xormask
+			Qsize++
+		}
+	}
+
+	stacksize := 0
+	for Qsize > 0 {
+		Qsize--
+		ki := Q[Qsize]
+		index := ki.index
+		if H[index].count == 0 {
+			continue // not actually possible after the initial scan
+		}
+
+		hash := ki.hash
+		hs := filter.geth012(hash)
+
+		stack[stacksize] = ki
+		stacksize++
+
+		// Remove key added to stack from all sets in the construction array and
+		// enqueue sets that now have one key.
+		H[hs.h0].xormask ^= hash
+		H[hs.h0].count--
+		if H[hs.h0].count == 1 {
+			Q[Qsize].index = hs.h0
+			Q[Qsize].hash = H[hs.h0].xormask
+			Qsize++
+		}
+		H[hs.h1].xormask ^= hash
+		H[hs.h1].count--
+		if H[hs.h1].count == 1 {
+			Q[Qsize].index = hs.h1
+			Q[Qsize].hash = H[hs.h1].xormask
+			Qsize++
+		}
+		H[hs.h2].xormask ^= hash
+		H[hs.h2].count--
+		if H[hs.h2].count == 1 {
+			Q[Qsize].index = hs.h2
+			Q[Qsize].hash = H[hs.h2].xormask
+			Qsize++
+		}
+	}
+
+	// if stacksize == size {
+	// 	// Success
+	// 	break
+	// }
+
+	// for i := range H {
+	// 	H[i] = xorset{0, 0}
+	// }
+	// filter.Seed = splitmix64(&rngcounter)
+	// }
 
 	// ref: Algorithm 4
-	stacksize := size
-	for stacksize > 0 {
-		stacksize--
-		ki := stack[stacksize]
-		hs := filter.geth012(ki.hash)
-		fp := uint8(fingerprint(ki.hash))
-		switch ki.index {
-		case hs.h0:
-			fp ^= filter.Fingerprints[hs.h1] ^ filter.Fingerprints[hs.h2]
-		case hs.h1:
-			fp ^= filter.Fingerprints[hs.h0] ^ filter.Fingerprints[hs.h2]
-		default:
-			fp ^= filter.Fingerprints[hs.h0] ^ filter.Fingerprints[hs.h1]
-		}
-		filter.Fingerprints[ki.index] = fp
-	}
+	// stacksize := size
+	if stacksize == size {
 
-	return filter, nil
+		for stacksize > 0 {
+			stacksize--
+			ki := stack[stacksize]
+			hs := filter.geth012(ki.hash)
+			fp := uint8(fingerprint(ki.hash))
+			switch ki.index {
+			case hs.h0:
+				fp ^= filter.Fingerprints[hs.h1] ^ filter.Fingerprints[hs.h2]
+			case hs.h1:
+				fp ^= filter.Fingerprints[hs.h0] ^ filter.Fingerprints[hs.h2]
+			default:
+				fp ^= filter.Fingerprints[hs.h0] ^ filter.Fingerprints[hs.h1]
+			}
+			filter.Fingerprints[ki.index] = fp
+		}
+		return filter, nil
+	}
+	return nil, errors.New("you probably have duplicate keys")
 }

--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -38,6 +38,18 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, true, fpp < 0.40)
 }
 
+func Test_DuplicateKeys(t *testing.T) {
+	keys := []uint64{1, 77, 31, 241, 303, 303}
+
+	expectedErr := "you probably have duplicate keys"
+
+	_, err := Populate(keys)
+
+	if err.Error() != expectedErr {
+		t.Fatalf("Unexpected error: %v, Expected: %v", err, expectedErr)
+	}
+}
+
 func BenchmarkPopulate100000(b *testing.B) {
 	testsize := 10000
 	keys := make([]uint64, testsize, testsize)


### PR DESCRIPTION
Removed iterations for duplicate key checks & added a test to check if an error is successfully generated when duplicate keys are present.
 
Fixes #3 

**Changes**

1. Previously in `xorfilter.go` a for true {} loop would run in the `Populate` function when populating the filter, this proved to be unnecessary and run as many times as maxIterations (100) were set or in the case where the keys had no duplicates present. 

I have found out that in the first iteration when generating the filter if the stacksize is less than the size of the input keys it would then mean that there are duplicate keys present in the input keys. The difference between the keysize and the reduced stacksize would be equal to the number of duplicate keys present and both stacksize & key size are equal when there is no duplicate present 

Here, I have removed the iterations count and added a check for only when to stacksize is the same as the keysize to then generate the filter else return an error.

2. Also added a unit test `Test_DuplicateKeys` to check if an error is successfully sent when there are duplicate keys present in `xorfilter_test.go`.

**Comments**

1. The iteration lines have been commented out as they are used in other filter programs in the project, will have to remove the need for them after the change.

2. Changed the err message from 

> too many iterations, you probably have duplicate keys

To 

> you probably have duplicate keys

3. The code block:

```
for i := range sets0 {
 sets0[i] = xorset{0, 0}
}
for i := range sets1 {
 sets1[i] = xorset{0, 0}
}
}
for i := range sets2 {
 sets2[i] = xorset{0, 0}
}
filter.Seed = splitmix64(&rngcounter)
```

happens after the check for `stacksize == size` as it's unreachable with the new code changes I had a doubt if they are still required.
