### PR TITLE
`PopulateBinaryFuse8` returns `too many iterations` for keys without duplicates

### DIFF
--- a/binaryfusefilter_test.go
+++ b/binaryfusefilter_test.go
@@ -4,20 +4,28 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const NUM_KEYS = 1e6
+const NUM_KEYS = 11500
+
+// const NUM_KEYS = 1000000
 const SMALL_NUM_KEYS = 100
 
-
 func TestBinaryFuse8Basic(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
 	keys := make([]uint64, NUM_KEYS)
 	for i := range keys {
 		keys[i] = rand.Uint64()
 	}
-	filter, _ := PopulateBinaryFuse8(keys)
+
+	filter, err := PopulateBinaryFuse8(keys)
+	require.NoError(t, err)
+
 	for _, v := range keys {
 		assert.Equal(t, true, filter.Contains(v))
 	}


### PR DESCRIPTION
I ran into a case where `PopulateBinaryFuse8` returned `too many iterations, you probably have duplicate keys` for a set of 11501 keys that doesn't contain any duplicates. I found that increasing `MaxIterations` to 217 allowed the filter to be built successfully. 

I was able to reproduce the issue in an existing test by setting `NUM_KEYS` keys to 11500 and running the tests multiple times with the `-count` option: i.e. `go test -run TestBinaryFuse8Basic -count 20`. This makes it fail reliably for me, whereas with the original `NUM_KEYS` or with some lower number like 10000 it never fails.

