### PR TITLE
chore: Configure release-please

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,0 +1,18 @@
+name: PR Conventions
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - main
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        with:
+          release-type: go
+          package-name: xorfilter


### PR DESCRIPTION
Related to https://github.com/FastFilter/xorfilter/issues/25

[Release-Please](https://github.com/googleapis/release-please) will create a running PR with all commits made since the last release. Once you're ready to cut a new release, just merge the PR.

One small caveat is that commits will only show up in the changelog if they follow semantic commit message guidelines (e.g. start with `fix`/`feat`/`chore`. Release-please uses them to determine what kind of version bump it should do. Very useful is that you can mark breaking changes with a bang, e.g. `fix!: bla` and it will do a major bump.
To make sure the commits follow this, i added an action for linting the PR title (assuming you squash-merge PRs).

Do you want to start with a specific version number? E.g. 0.1.0 or something like that?