### PR TITLE
fix: Use correct default branch name for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - master
 
 name: release-please
 jobs:


### PR DESCRIPTION
Follow-up to #26 

This makes the action run on pushes to `master` (the actual default branch of the repo).

I marked this commit as "fix", so it will trigger release-please to propose a new release. You don't need to create that release immediately though because this commit has no outward facing changes. Usually these changes should be tagged "chore", this is just for demonstration of the functionality. You'll be able to remove it from the changelog if you want to.

One more note: If you use "create a merge commit" instead of "squash merge" this will have an impact over what the changelog picks up.
Release please will take all semantic commits from the `master` branch and compile a changelog for them.

Without a squash merge, you will not get a good experience out of this:
- A merge commit is not a semantic commit unless you manually edit it when merging
- You likely don't want every single commit from a contributors PR to show up in the changelog