### PR TITLE
mod tidy and linter warnings

### DIFF
--- a/binaryfusefilter.go
+++ b/binaryfusefilter.go
@@ -110,7 +110,7 @@ func PopulateBinaryFuse8(keys []uint64) (*BinaryFuse8, error) {
 	// this could be used to compute the mod3
 	// tabmod3 := [5]uint8{0,1,2,0,1}
 	iterations := 0
-	for true {
+	for {
 		iterations += 1
 		if iterations > MaxIterations {
 			// The probability of this happening is lower than the
@@ -123,7 +123,7 @@ func PopulateBinaryFuse8(keys []uint64) (*BinaryFuse8, error) {
 			blockBits += 1
 		}
 		startPos := make([]uint, 1<<blockBits)
-		for i, _ := range startPos {
+		for i := range startPos {
 			// important: we do not want i * size to overflow!!!
 			startPos[i] = uint((uint64(i) * uint64(size)) >> blockBits)
 		}

--- a/binaryfusefilter_test.go
+++ b/binaryfusefilter_test.go
@@ -104,14 +104,14 @@ func TestBinaryFuse8Small(t *testing.T) {
 }
 
 func BenchmarkBinaryFuse8Populate1000000(b *testing.B) {
-	keys := make([]uint64, NUM_KEYS, NUM_KEYS)
+	keys := make([]uint64, NUM_KEYS)
 	for i := range keys {
 		keys[i] = rand.Uint64()
 	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		PopulateBinaryFuse8(keys)
+		bogusbinary, _ = PopulateBinaryFuse8(keys)
 	}
 }
 
@@ -262,18 +262,19 @@ func Test_DuplicateKeysBinaryFuseDup_Issue30(t *testing.T) {
 }
 
 var bogusbinary *BinaryFuse8
+var bogusbool bool
 
 func BenchmarkConstructBinaryFuse8(b *testing.B) {
 	bigrandomarrayInit()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		PopulateBinaryFuse8(bigrandomarray)
+		bogusbinary, _ = PopulateBinaryFuse8(bigrandomarray)
 	}
 }
 
 func BenchmarkBinaryFuse8Contains1000000(b *testing.B) {
-	keys := make([]uint64, NUM_KEYS, NUM_KEYS)
+	keys := make([]uint64, NUM_KEYS)
 	for i := range keys {
 		keys[i] = rand.Uint64()
 	}
@@ -281,7 +282,7 @@ func BenchmarkBinaryFuse8Contains1000000(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		filter.Contains(keys[n%len(keys)])
+		bogusbool = filter.Contains(keys[n%len(keys)])
 	}
 }
 
@@ -289,7 +290,7 @@ var binaryfusedbig *BinaryFuse8
 
 func binaryfusedbigInit() {
 	fmt.Println("Binary Fuse setup")
-	keys := make([]uint64, 50000000, 50000000)
+	keys := make([]uint64, 50000000)
 	for i := range keys {
 		keys[i] = rand.Uint64()
 	}
@@ -303,7 +304,7 @@ func BenchmarkBinaryFuse8Contains50000000(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		binaryfusedbig.Contains(rand.Uint64())
+		bogusbool = binaryfusedbig.Contains(rand.Uint64())
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,14 @@
 module github.com/FastFilter/xorfilter
 
-go 1.13
+go 1.17
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/cespare/xxhash v1.1.0
+	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -179,7 +179,7 @@ func BenchmarkXor8bigContains50000000(b *testing.B) {
 	}
 }
 
-func TestfsdIssue35_basic(t *testing.T) {
+func TestFSDIssue35_basic(t *testing.T) {
 	hashes := make([]uint64, 0)
 	for i := 0; i < 2000; i++ {
 		v := encode(int32(rand.Intn(10)), int32(rand.Intn(100000)))


### PR DESCRIPTION
Bumped to Go 1.17 in go.mo
Run a mod tidy for missing dependencies
Fixed a couple of linter warnings
Assigned return values in benchmarks