### PR TITLE
Use newer `slices.Sort` in `pruneDuplicates`

### DIFF
--- a/xorfilter.go
+++ b/xorfilter.go
@@ -3,7 +3,7 @@ package xorfilter
 import (
 	"errors"
 	"math"
-	"sort"
+	"slices"
 )
 
 func murmur64(h uint64) uint64 {
@@ -287,9 +287,7 @@ func Populate(keys []uint64) (*Xor8, error) {
 }
 
 func pruneDuplicates(array []uint64) []uint64 {
-	sort.Slice(array, func(i, j int) bool {
-		return array[i] < array[j]
-	})
+	slices.Sort(array)
 	pos := 0
 	for i := 1; i < len(array); i++ {
 		if array[i] != array[pos] {


### PR DESCRIPTION
The new `slices.Sort` function introduced in Go 1.21 [^1] is faster than the older `sort.Slice` approach. The documentation for `sort.Slice` also recommends using `slices.Sort` in most cases [^2].

Benchmark:

```go
func BenchmarkSort(b *testing.B) {
	array := []uint64{0, 42, 10, 8}

	b.Run("sort.Slice", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			sort.Slice(array, func(i, j int) bool {
				return array[i] < array[j]
			})
		}
	})

	b.Run("slices.Sort", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			slices.Sort(array)
		}
	})
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/FastFilter/xorfilter
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkSort/sort.Slice-16         	 4290086	       284.0 ns/op	      56 B/op	       2 allocs/op
BenchmarkSort/slices.Sort-16        	62395050	        19.53 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/FastFilter/xorfilter	3.739s
```

[^1]: https://pkg.go.dev/slices#Sort
[^2]: https://pkg.go.dev/sort#Slice