### PR TITLE
test: use math/rand/v2

### DIFF
--- a/binaryfusefilter_test.go
+++ b/binaryfusefilter_test.go
@@ -2,7 +2,7 @@ package xorfilter
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/cespare/xxhash"
@@ -43,9 +43,9 @@ func TestBinaryFuseNBasic(t *testing.T) {
 	}
 	keys = keys[:cut]
 	for trial := 0; trial < 10; trial++ {
-		rand.Seed(int64(trial))
+		r := rand.New(rand.NewPCG(uint64(trial), uint64(trial)))
 		for i := range keys {
-			keys[i] = rand.Uint64()
+			keys[i] = r.Uint64()
 		}
 		filter, _ = NewBinaryFuse[testType](keys)
 		for _, v := range keys {
@@ -93,9 +93,9 @@ func TestBinaryFuseNSmall(t *testing.T) {
 	}
 	keys = keys[:cut]
 	for trial := 0; trial < 10; trial++ {
-		rand.Seed(int64(trial))
+		r := rand.New(rand.NewPCG(uint64(trial), uint64(trial)))
 		for i := range keys {
-			keys[i] = rand.Uint64()
+			keys[i] = r.Uint64()
 		}
 		filter, _ = NewBinaryFuse[testType](keys)
 		for _, v := range keys {
@@ -317,7 +317,7 @@ func TestBinaryFuseN_Issue35(t *testing.T) {
 	for test := 0; test < 100; test++ {
 		hashes := make([]uint64, 0)
 		for i := 0; i < 40000; i++ {
-			v := encode(int32(rand.Intn(10)), int32(rand.Intn(100000)))
+			v := encode(rand.Int32N(10), rand.Int32N(100000))
 			hashes = append(hashes, xxhash.Sum64(v))
 		}
 		inner, err := NewBinaryFuse[testType](hashes)

--- a/xorfilter_test.go
+++ b/xorfilter_test.go
@@ -2,7 +2,7 @@ package xorfilter
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 	"unsafe"
@@ -182,7 +182,7 @@ func BenchmarkXor8bigContains50000000(b *testing.B) {
 func TestFSDIssue35_basic(t *testing.T) {
 	hashes := make([]uint64, 0)
 	for i := 0; i < 2000; i++ {
-		v := encode(int32(rand.Intn(10)), int32(rand.Intn(100000)))
+		v := encode(rand.Int32N(10), rand.Int32N(100000))
 		hashes = append(hashes, xxhash.Sum64(v))
 	}
 	inner, err := Populate(hashes)
@@ -202,7 +202,7 @@ func Test_Issue35_basic(t *testing.T) {
 	for test := 0; test < 100; test++ {
 		hashes := make([]uint64, 0)
 		for i := 0; i < 40000; i++ {
-			v := encode(int32(rand.Intn(10)), int32(rand.Intn(100000)))
+			v := encode(rand.Int32N(10), rand.Int32N(100000))
 			hashes = append(hashes, xxhash.Sum64(v))
 		}
 		inner, err := PopulateBinaryFuse8(hashes)


### PR DESCRIPTION
We upgraded our minimum Go version in PR https://github.com/FastFilter/xorfilter/pull/39, which allows us to use the `math/rand/v2` package, a more 'correct' implementation compared to `math/rand`.

One of your papers was mentioned in the blog post: https://go.dev/blog/randv2 :wink:

> In 2018, [Daniel Lemire found an algorithm](https://arxiv.org/abs/1805.10941) that avoids the divisions nearly all the time (see also his [2019 blog post](https://lemire.me/blog/2019/06/06/nearly-divisionless-random-integer-generation-on-various-systems/)). In math/rand, adopting Lemire’s algorithm would make Intn(1000) 20-30% faster, but we can’t: the faster algorithm generates different values than the standard conversion, breaking repeatability.