### PR TITLE
Use built-in `clear` function to reset `xorset`

### DIFF
--- a/xorfilter.go
+++ b/xorfilter.go
@@ -99,14 +99,6 @@ func scanCount(Qi []keyindex, setsi []xorset) ([]keyindex, int) {
 	return Qi, QiSize
 }
 
-// fill setsi to xorset{0, 0}
-func resetSets(setsi []xorset) []xorset {
-	for i := range setsi {
-		setsi[i] = xorset{0, 0}
-	}
-	return setsi
-}
-
 // The maximum  number of iterations allowed before the populate function returns an error
 var MaxIterations = 1024
 
@@ -262,9 +254,9 @@ func Populate(keys []uint64) (*Xor8, error) {
 			size = len(keys)
 		}
 
-		sets0 = resetSets(sets0)
-		sets1 = resetSets(sets1)
-		sets2 = resetSets(sets2)
+		clear(sets0)
+		clear(sets1)
+		clear(sets2)
 
 		filter.Seed = splitmix64(&rngcounter)
 	}


### PR DESCRIPTION
Reference: https://go.dev/ref/spec#Clear

The built-in `clear` function introduced in Go 1.21 does the job of `resetSets` function.

Playground example: https://go.dev/play/p/7d4DsuYqY2t

```go
package main

import "fmt"

type xorset struct {
	xormask uint64
	count   uint32
}

func main() {
	sets0 := []xorset{
		xorset{1, 1},
		xorset{2, 2},
		xorset{3, 3},
	}

	fmt.Println(sets0)
	clear(sets0)
	fmt.Println(sets0)
}
```

```
[{1 1} {2 2} {3 3}]
[{0 0} {0 0} {0 0}]
```