### PR TITLE
Allow initial sizing of BinaryFuseBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ When building many filters, memory can be reused (reducing allocation and GC
 overhead) with a `BinaryFuseBuilder`:
 ```Go
 var builder xorfilter.BinaryFuseBuilder
+builder = xorfilter.MakeBinaryFuseBuilder[uint16](initialSize)  // Optional
 for {
-    filter8, _ := BuildBinaryFuse[uint8](&builder, keys)
-    filter16, _ := BuildBinaryFuse[uint16](&builder, keys)
-    ...
+  filter16, _ := BuildBinaryFuse[uint16](&builder, keys)
+  ...
 }
 ```
 


### PR DESCRIPTION
#### Simplify segment count calculation


#### Allow initial sizing of BinaryFuseBuilder

Add `MakeBinaryFuseBuilder` which pre-initializes a binary fuse
builder to a certain initial size, guaranteeing no allocations up to
that size. This avoids reallocations as the buffers grow.

We also improve the `reuseBuffer` method to use an `append` pattern
(relying on the internal formulas for slice growth) and isolate the
unsafe hack to the single place where it is needed now (fingerprints
slice).